### PR TITLE
Fixed issue with Travis-CI building failing due to missing library

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,9 @@ python:
 install:
   - pip install pytest
   - pip install threatconnect
+  - pip install tcex
   - pip install bs4
   - pip install requests
+  - pip install inflect
 script:
   - pytest

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ upstream:
 	git remote -v;
 
 doctest:
-	cd docs && virtualenv ~/.venv/tc_developer_docs && source ~/.venv/tc_developer_docs/bin/activate && pip install sphinx && pip install recommonmark && pip install tcex && pip install sphinx_rtd_theme && sphinx-build -T -E -d _build/doctrees-readthedocs -D language=en . _build/html
+	cd docs && virtualenv ~/.venv/tc_developer_docs && source ~/.venv/tc_developer_docs/bin/activate && pip install sphinx && pip install recommonmark && pip install inflect && pip install tcex && pip install sphinx_rtd_theme && sphinx-build -T -E -d _build/doctrees-readthedocs -D language=en . _build/html

--- a/Makefile
+++ b/Makefile
@@ -61,4 +61,4 @@ upstream:
 	git remote -v;
 
 doctest:
-	cd docs && virtualenv ~/.venv/tc_developer_docs && source ~/.venv/tc_developer_docs/bin/activate && pip install sphinx && pip install recommonmark && pip install inflect && pip install tcex && pip install sphinx_rtd_theme && sphinx-build -T -E -d _build/doctrees-readthedocs -D language=en . _build/html
+	cd docs && virtualenv ~/.venv/tc_developer_docs && source ~/.venv/tc_developer_docs/bin/activate && pip install sphinx && pip install recommonmark && pip install tcex && pip install sphinx_rtd_theme && sphinx-build -T -E -d _build/doctrees-readthedocs -D language=en . _build/html


### PR DESCRIPTION
Added missing library to .travis.yml to resolve a failing build. Reverted previous change to Makefile.